### PR TITLE
Restore .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
+.gradle
+build/
+!**/gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+
 .DS_Store
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+**/.vscode/
+**/.devcontainer
+**/bin/


### PR DESCRIPTION
Reduces the chance that bogus files are added to the repo. This is particularly needed since so many people use `git add .` all the time. Using `git add -u` will add any files that are already tracked and updated and also helps keep cruft out of a repo.
